### PR TITLE
Allow empty search string

### DIFF
--- a/public/js/controllers/ApplicationController.js
+++ b/public/js/controllers/ApplicationController.js
@@ -77,16 +77,13 @@ App.ApplicationController = Ember.Controller.extend({
             advancedOptions = {};
         }
 
-        if(value.length){
-            this.set('query', value );
-            // wrap everything into 1 url resource parameter
-            var payload = $.param({
-                query: value,
-                filters: advancedOptions
-            });
-            this.transitionToRoute('summarySearch', payload);
-        }
-
+        this.set('query', value );
+        // wrap everything into 1 url resource parameter
+        var payload = $.param({
+            query: value,
+            filters: advancedOptions
+        });
+        this.transitionToRoute('summarySearch', payload);
     },
 
     queryChanged: function(){

--- a/public/js/models/OnionooSummary.js
+++ b/public/js/models/OnionooSummary.js
@@ -33,7 +33,14 @@ App.OnionooSummary.reopenClass({
     },
     findWithFilter: function(query, filter){
         var that = this;
+        
         App.incrementProperty('loading');
+        
+        // only add search param if query is not empty
+        var searchParamString = '';
+        if (query.length) {
+            searchParamString = '&search='+query; 
+        }
 
         // manually set params
         var advancedParamsString = '&';
@@ -47,11 +54,6 @@ App.OnionooSummary.reopenClass({
         // remove last &
         advancedParamsString = advancedParamsString.slice(0, -1);
         
-        var searchParamString = '';
-        if (query.length) {
-            searchParamString = '&search='+query; 
-        }
-
         return $.getJSON('https://onionoo.torproject.org/summary?limit=50' + searchParamString + advancedParamsString, {}).then(function(result){
             App.decrementProperty('loading');
 

--- a/public/js/models/OnionooSummary.js
+++ b/public/js/models/OnionooSummary.js
@@ -33,7 +33,6 @@ App.OnionooSummary.reopenClass({
     },
     findWithFilter: function(query, filter){
         var that = this;
-
         App.incrementProperty('loading');
 
         // manually set params
@@ -47,8 +46,13 @@ App.OnionooSummary.reopenClass({
         }
         // remove last &
         advancedParamsString = advancedParamsString.slice(0, -1);
+        
+        var searchParamString = '';
+        if (query.length) {
+            searchParamString = '&search='+query; 
+        }
 
-        return $.getJSON('https://onionoo.torproject.org/summary?limit=50&search=' + query + advancedParamsString, {}).then(function(result){
+        return $.getJSON('https://onionoo.torproject.org/summary?limit=50' + searchParamString + advancedParamsString, {}).then(function(result){
             App.decrementProperty('loading');
 
             return that.applySummaryDefaults(result, {
@@ -63,7 +67,6 @@ App.OnionooSummary.reopenClass({
         App.incrementProperty('loading');
         return $.getJSON('https://onionoo.torproject.org/summary?limit=50&search=' + query, {}).then(function(result){
             App.decrementProperty('loading');
-
             return that.applySummaryDefaults(result, {
                 relay: defaultOnionooRelaySummary,
                     bridge: defaultOnionooBridgeSummary

--- a/public/js/models/OnionooSummary.js
+++ b/public/js/models/OnionooSummary.js
@@ -35,7 +35,7 @@ App.OnionooSummary.reopenClass({
         var that = this;
         
         App.incrementProperty('loading');
-        
+
         // only add search param if query is not empty
         var searchParamString = '';
         if (query.length) {


### PR DESCRIPTION
This allows to search with an empty search string. If the search string is empty, the `search` string does not get added to the url.
It is then possible to search for example for every Tor node within a given AS.

I preferred to allow the empty string instead of introducing some wildcard character like *, since the onionoo API works the way that `search` is just treated like all the other filters like `as` as far is i understand.

If you don't like the approach, i'd be happy to change it if you give me some advice.
