### PR TITLE
Ajax wrapper

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,6 +49,7 @@ module.exports = function(grunt) {
             // helper
             'js/helpers/formatter.js',
             'js/helpers/util.js',
+            'js/helpers/ajax.js',
             'js/helpers/handlebarsHelper.js',
             'js/helpers/dataTablesRenderer.js',
 
@@ -318,16 +319,14 @@ module.exports = function(grunt) {
                 dest : '<%= globe.test %>karma.conf.js'
             },
             app: {
-                src: '<%= globe.src %>js/application/intro.js',
-                dest: '<%= globe.tmp %>js/application/intro.js'
+                files: {
+                    '<%= globe.tmp %>js/application/intro.js': '<%= globe.src %>js/application/intro.js',
+                    '<%= globe.tmp %>js/helpers/ajax.js': '<%= globe.src %>js/helpers/ajax.js'
+                }
             }
         },
 
         env: {
-            options : {
-                /* Shared Options Hash */
-                //globalOption : 'foo'
-            },
             dev: {
                 NODE_ENV : 'DEVELOPMENT'
             },

--- a/src/js/application/intro.js
+++ b/src/js/application/intro.js
@@ -1,4 +1,4 @@
-/*global $, prepareForTesting, Ember, jQuery, InstallTrigger */
+/*global $, prepareForTesting, Ember, Em, jQuery, InstallTrigger */
 'use strict';
 
 // create ember application and set namespace
@@ -13,6 +13,9 @@ if($.isFunction(window.prepareForTesting)){
 // create Ember application with some extra methods
 GLOBE = GLOBE.reopen({
 
+    // api baseurl
+    api: 'https://onionoo.torproject.org',
+
     // model defaults
     defaults: [],
 
@@ -23,7 +26,7 @@ GLOBE = GLOBE.reopen({
     loading: 0,
 
     // application alert
-    alert: Ember.Object.create({
+    alert: Em.Object.create({
         search: null
     }),
 
@@ -49,7 +52,7 @@ GLOBE = GLOBE.reopen({
      */
     setAlert: function(location, type, msg){
         if(this.get('alert').hasOwnProperty(location)){
-            this.set('alert.' + location, Ember.Object.create({
+            this.set('alert.' + location, Em.Object.create({
                 type: type,
                 msg: msg
             }));
@@ -463,6 +466,6 @@ jQuery.fn.dataTableExt.oSort['port-asc']  = function(x,y) {
     return xInt > yInt ? 1 : xInt < yInt ? -1 : 0;
 };
 
-GLOBE.TextField = Ember.TextField.extend({
+GLOBE.TextField = Em.TextField.extend({
     attributeBindings: ['accept', 'autocomplete', 'autofocus', 'name', 'required']
 });

--- a/src/js/components/AlertBoxComponent.js
+++ b/src/js/components/AlertBoxComponent.js
@@ -1,5 +1,5 @@
-/*global GLOBE, Ember */
-GLOBE.AlertBoxComponent = Ember.Component.extend({
+/*global GLOBE, Em */
+GLOBE.AlertBoxComponent = Em.Component.extend({
     tagName: 'div',
     baseClass: 'alert',
 

--- a/src/js/components/LoadingIndicatorComponent.js
+++ b/src/js/components/LoadingIndicatorComponent.js
@@ -1,5 +1,5 @@
-/*global GLOBE, Ember */
-GLOBE.LoadingIndicatorComponent = Ember.Component.extend({
+/*global GLOBE, Em */
+GLOBE.LoadingIndicatorComponent = Em.Component.extend({
     isDataLoaded: function(){
 
         // change isDataLoaded depending on GLOBE.loading number

--- a/src/js/controllers/ApplicationController.js
+++ b/src/js/controllers/ApplicationController.js
@@ -1,5 +1,5 @@
-/*global $, GLOBE, Ember */
-GLOBE.ApplicationController = Ember.Controller.extend({
+/*global $, GLOBE, Em */
+GLOBE.ApplicationController = Em.Controller.extend({
     needs: ['relaySearch'],
     value: '',
     query: '',

--- a/src/js/controllers/BridgeDetailController.js
+++ b/src/js/controllers/BridgeDetailController.js
@@ -1,5 +1,5 @@
-/*global $, GLOBE, Ember */
-GLOBE.BridgeDetailController = Ember.ObjectController.extend({
+/*global $, GLOBE, Em */
+GLOBE.BridgeDetailController = Em.ObjectController.extend({
     bandwidthData: {},
     weightData: {},
     content: {},

--- a/src/js/controllers/RelayDetailController.js
+++ b/src/js/controllers/RelayDetailController.js
@@ -1,5 +1,5 @@
-/*global $, GLOBE, Ember */
-GLOBE.RelayDetailController = Ember.ObjectController.extend({
+/*global $, GLOBE, Em */
+GLOBE.RelayDetailController = Em.ObjectController.extend({
     bandwidthData: {},
     weightData: {},
     content: {},

--- a/src/js/controllers/SummarySearchController.js
+++ b/src/js/controllers/SummarySearchController.js
@@ -1,5 +1,5 @@
-/*global GLOBE, Ember */
-GLOBE.SummarySearchController = Ember.ArrayController.extend({
+/*global GLOBE, Em */
+GLOBE.SummarySearchController = Em.ArrayController.extend({
     needs: 'application',
     content: [],
     active: 'relays',
@@ -9,13 +9,13 @@ GLOBE.SummarySearchController = Ember.ArrayController.extend({
     query: '',
 
     summaries: {},
-    relays: Ember.ArrayController.create({
-        content: Ember.A([]),
-        summaries: Ember.A([])
+    relays: Em.ArrayController.create({
+        content: Em.A([]),
+        summaries: Em.A([])
     }),
-    bridges: Ember.ArrayController.create({
-        content: Ember.A([]),
-        summaries: Ember.A([])
+    bridges: Em.ArrayController.create({
+        content: Em.A([]),
+        summaries: Em.A([])
     }),
 
     relaysActive: function () {

--- a/src/js/controllers/Top10Controller.js
+++ b/src/js/controllers/Top10Controller.js
@@ -1,5 +1,5 @@
-/*global GLOBE, Ember */
-GLOBE.Top10Controller = Ember.ArrayController.extend({
+/*global GLOBE, Em */
+GLOBE.Top10Controller = Em.ArrayController.extend({
     needs: ['application'],
     content: [],
     relays: [],

--- a/src/js/helpers/ajax.js
+++ b/src/js/helpers/ajax.js
@@ -1,0 +1,52 @@
+/*global GLOBE, Em */
+
+/**
+ * $.ajax wrapper that uses Ember.run to run async code.
+ * Necessary for async Ember testing.
+ * Inspired by discourse ajax wrapper.
+ *
+ * @see {@link https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/mixins/ajax.js}
+ * @param {Object} settings
+ * @returns {Promise}
+ */
+GLOBE.ajax = function (settings) {
+    return new Em.RSVP.Promise(function(resolve, reject) {
+
+    // @if NODE_ENV == 'TESTING'
+        // only available for testing
+        var fixture = GLOBE.TESTING_FIXTURES && GLOBE.TESTING_FIXTURES[settings.url];
+        if (fixture) {
+            Em.run(null, resolve, fixture);
+        } else {
+    // @endif
+
+            // prefix url
+            settings.url = GLOBE.get('api') + settings.url;
+
+            settings.success = function(response) {
+                Em.run(null, resolve, response);
+            };
+            settings.error = function(jqXHR, textStatus) {
+                Em.run(null, reject, textStatus);
+            };
+            Em.$.ajax(settings);
+
+    // @if NODE_ENV == 'TESTING'
+        }
+    // @endif
+    });
+};
+/**
+ * Calls GLOBE.ajax with parameters to imitate $.getJSON
+ * @see {@link GLOBE.ajax}
+ * @param {String} url
+ * @param {Object} [data]
+ * @returns {Promise}
+ */
+GLOBE.getJSON = function (url, data) {
+    return GLOBE.ajax({
+        dataType: 'json',
+        data: data || {},
+        url: url
+    });
+};

--- a/src/js/helpers/dataTablesRenderer.js
+++ b/src/js/helpers/dataTablesRenderer.js
@@ -67,11 +67,10 @@ GLOBE.DataTableRenderer = {
      * @returns {String} extracted port
      */
     firstPort: function (data, type) {
-        data = data[0];
         if (type === 'display') {
-            return GLOBE.Formatter.extractPort(data);
+            return GLOBE.Formatter.extractPort(data[0]);
         }
-        return data;
+        return data[0];
     },
     /**
      * @see {@link GLOBE.Formatter.extractPort}

--- a/src/js/helpers/handlebarsHelper.js
+++ b/src/js/helpers/handlebarsHelper.js
@@ -1,8 +1,8 @@
-/*global GLOBE, Handlebars, Ember, moment */
+/*global GLOBE, Handlebars, Em, moment */
 /**
  * @see {@link GLOBE.Formatter.boolean()}
  */
-Ember.Handlebars.helper('truefalse', function(value){
+Em.Handlebars.helper('truefalse', function(value){
     var wrapped = GLOBE.Formatter.boolean(value);
     return new Handlebars.SafeString(wrapped);
 });
@@ -10,7 +10,7 @@ Ember.Handlebars.helper('truefalse', function(value){
 /**
  * @see {@link GLOBE.Formatter.bandwidth()}
  */
-Ember.Handlebars.helper('bandwidth', function(value){
+Em.Handlebars.helper('bandwidth', function(value){
     var formatted = GLOBE.Formatter.bandwidth(value);
     return new Handlebars.SafeString(formatted);
 });
@@ -18,7 +18,7 @@ Ember.Handlebars.helper('bandwidth', function(value){
 /**
  * Uses {@link GLOBE.static.countries} to get the full name for a country key
  */
-Ember.Handlebars.registerBoundHelper('fullCountry', function(value){
+Em.Handlebars.registerBoundHelper('fullCountry', function(value){
     value = Handlebars.Utils.escapeExpression(value);
 
     var fullCountry = '';
@@ -32,7 +32,7 @@ Ember.Handlebars.registerBoundHelper('fullCountry', function(value){
 /**
  * @see {@link GLOBE.Formatter.countryFlag()}
  */
-Ember.Handlebars.registerBoundHelper('prettyCountryFlag', function(value){
+Em.Handlebars.registerBoundHelper('prettyCountryFlag', function(value){
     value = Handlebars.Utils.escapeExpression(value);
 
     var countryLabel = GLOBE.Formatter.countryFlag(value);
@@ -42,7 +42,7 @@ Ember.Handlebars.registerBoundHelper('prettyCountryFlag', function(value){
 /**
  * @see {@link GLOBE.Formatter.countryFlag()}
  */
-Ember.Handlebars.registerBoundHelper('flaggifyShort', function(value){
+Em.Handlebars.registerBoundHelper('flaggifyShort', function(value){
     value = Handlebars.Utils.escapeExpression(value);
     var withImage = GLOBE.Formatter.countryFlag(value);
     return new Handlebars.SafeString(withImage);
@@ -51,7 +51,7 @@ Ember.Handlebars.registerBoundHelper('flaggifyShort', function(value){
 /**
  * Generates HTML that displays an flag icon with flag title
  */
-Ember.Handlebars.registerBoundHelper('flaggifyLong', function(value){
+Em.Handlebars.registerBoundHelper('flaggifyLong', function(value){
     var map = GLOBE.static.icons;
     value = Handlebars.Utils.escapeExpression(value);
     var withImage = value;
@@ -65,7 +65,7 @@ Ember.Handlebars.registerBoundHelper('flaggifyLong', function(value){
  * Uses the 'long' variant to generate an uptime string
  * @see {@title GLOBE.Util.UptimeCalculator}
  */
-Ember.Handlebars.helper('uptimeFull', function(value){
+Em.Handlebars.helper('uptimeFull', function(value){
     if(!value){
         return '';
     }
@@ -78,7 +78,7 @@ Ember.Handlebars.helper('uptimeFull', function(value){
  * Uses the 'short' variant to generate an uptime string
  * @see {@title GLOBE.Util.UptimeCalculator}
  */
-Ember.Handlebars.helper('uptimeShort', function(value){
+Em.Handlebars.helper('uptimeShort', function(value){
     if(!value){
         return '';
     }
@@ -90,7 +90,7 @@ Ember.Handlebars.helper('uptimeShort', function(value){
 /**
  * @see {@link GLOBE.Formatter.extractPort()}
  */
-Ember.Handlebars.helper('extractPort', function(value){
+Em.Handlebars.helper('extractPort', function(value){
     value = Handlebars.Utils.escapeExpression(value);
 
     var port = GLOBE.Formatter.extractPort(value);
@@ -101,7 +101,7 @@ Ember.Handlebars.helper('extractPort', function(value){
 /**
  * uses {@link http://momentjs.com/docs/#/displaying/fromnow/} to display the difference from now and a given time
  */
-Ember.Handlebars.helper('fromNow', function(value){
+Em.Handlebars.helper('fromNow', function(value){
     var fromNow = '',
         valMoment = moment(value);
 
@@ -114,6 +114,6 @@ Ember.Handlebars.helper('fromNow', function(value){
 /**
  * @see {@link GLOBE.Formatter.familyToFingerprint()}
  */
-Ember.Handlebars.helper('familyToFingerprint', function(value){
+Em.Handlebars.helper('familyToFingerprint', function(value){
     return new Handlebars.SafeString(GLOBE.Formatter.familyToFingerprint(value));
 });

--- a/src/js/models/OnionooBandwidthHistory.js
+++ b/src/js/models/OnionooBandwidthHistory.js
@@ -1,6 +1,6 @@
-/*global $, GLOBE, Ember */
+/*global GLOBE, Em */
 
-GLOBE.OnionooBandwidthHistory = Ember.Object.extend({});
+GLOBE.OnionooBandwidthHistory = Em.Object.extend({});
 GLOBE.OnionooBandwidthHistory.reopenClass({
 
     /**
@@ -18,8 +18,8 @@ GLOBE.OnionooBandwidthHistory.reopenClass({
 
         hashedFingerprint = hashedFingerprint.toUpperCase();
 
-        var url = 'https://onionoo.torproject.org/bandwidth?lookup=' + hashedFingerprint;
-        return $.getJSON(url, {}).then(function(result){
+        var url = '/bandwidth?lookup=' + hashedFingerprint;
+        return GLOBE.getJSON(url).then(function(result){
 
             var relays = {
                 history:{

--- a/src/js/models/OnionooDetail.js
+++ b/src/js/models/OnionooDetail.js
@@ -1,9 +1,9 @@
-/*global $, GLOBE, Ember, moment */
+/*global $, GLOBE, Em, moment */
 
-GLOBE.OnionooRelayDetail = Ember.Object.extend({});
-GLOBE.OnionooBridgeDetail = Ember.Object.extend({});
+GLOBE.OnionooRelayDetail = Em.Object.extend({});
+GLOBE.OnionooBridgeDetail = Em.Object.extend({});
 
-GLOBE.OnionooDetail = Ember.Object.extend({});
+GLOBE.OnionooDetail = Em.Object.extend({});
 GLOBE.OnionooDetail.reopenClass({
     applyDetailDefaults: function(result, defaults){
         var details = {
@@ -101,11 +101,11 @@ GLOBE.OnionooDetail.reopenClass({
         advancedParamsString = advancedParamsString.slice(0, -1);
 
         // build request url
-        var url = 'https://onionoo.torproject.org/details?limit=' + GLOBE.static.numbers.maxSearchResults;
+        var url = '/details?limit=' + GLOBE.static.numbers.maxSearchResults;
 
         url += searchParamString + advancedParamsString + fieldParamString;
 
-        return $.getJSON(url).then(function(result){
+        return GLOBE.getJSON(url).then(function(result){
             // getJSON success callback
 
             GLOBE.decrementProperty('loading');
@@ -117,7 +117,7 @@ GLOBE.OnionooDetail.reopenClass({
         }, function () {
             // getJSON error callback
             GLOBE.decrementProperty('loading');
-            return GLOBE.static.errors.INVALID_SEARCH_TERM;
+            throw GLOBE.static.errors.INVALID_SEARCH_TERM;
         });
 
     },
@@ -145,9 +145,9 @@ GLOBE.OnionooDetail.reopenClass({
 
             GLOBE.incrementProperty('loading');
 
-            var url = 'https://onionoo.torproject.org/details?lookup=' + hashedFingerprint;
+            var url = '/details?lookup=' + hashedFingerprint;
 
-            return $.getJSON(url, {}).then(function(result){
+            return GLOBE.getJSON(url).then(function(result){
                 var detailsObj = that.applyDetailDefaults(result, {
                     relay: GLOBE.defaults.OnionooRelayDetail,
                     bridge: GLOBE.defaults.OnionooBridgeDetail
@@ -166,14 +166,9 @@ GLOBE.OnionooDetail.reopenClass({
             });
 
         }else{
-            var defer = new $.Deferred();
-
-            setTimeout(function(){
-                // wait 4 ms (http://stackoverflow.com/a/9647221) then resolve with stored detail
-                defer.resolve(storedDetail);
-            }, 4);
-
-            return defer.promise();
+            return new Em.RSVP.Promise(function (resolve) {
+                resolve(storedDetail);
+            });
         }
     },
 
@@ -189,14 +184,14 @@ GLOBE.OnionooDetail.reopenClass({
         // right now a fixed order
         order = '-consensus_weight';
 
-        var url = 'https://onionoo.torproject.org/details?type=relay';
+        var url = '/details?type=relay';
         url += '&order=' + order;
         url += '&limit=10';
         url += '&fields=' + fields.join(',');
         url += '&running=true';
 
         GLOBE.incrementProperty('loading');
-        return $.getJSON(url).then(function(result){
+        return GLOBE.getJSON(url).then(function(result){
             GLOBE.decrementProperty('loading');
 
             return that.applyDetailDefaults(result, {

--- a/src/js/models/OnionooWeightsHistory.js
+++ b/src/js/models/OnionooWeightsHistory.js
@@ -1,5 +1,5 @@
-/*global $, GLOBE, Ember */
-GLOBE.OnionooWeightsHistory = Ember.Object.extend({});
+/*global GLOBE, Em */
+GLOBE.OnionooWeightsHistory = Em.Object.extend({});
 GLOBE.OnionooWeightsHistory.reopenClass({
 
     /**
@@ -17,9 +17,9 @@ GLOBE.OnionooWeightsHistory.reopenClass({
 
         hashedFingerprint = hashedFingerprint.toUpperCase();
 
-        var url = 'https://onionoo.torproject.org/weights?lookup=' + hashedFingerprint;
+        var url = '/weights?lookup=' + hashedFingerprint;
 
-        return $.getJSON(url, {}).then(function(result){
+        return GLOBE.getJSON(url).then(function(result){
             var history = {
                 advertisedBandwidth: {},
                 consensusWeightFraction: {},

--- a/src/js/models/TemporaryStore.js
+++ b/src/js/models/TemporaryStore.js
@@ -1,8 +1,8 @@
-/*global GLOBE, Ember */
+/*global GLOBE, Em */
 /**
  * Storage to temporary hold anything
  */
-GLOBE.TemporaryStore = Ember.Object.extend({});
+GLOBE.TemporaryStore = Em.Object.extend({});
 GLOBE.TemporaryStore.reopenClass({
 
     // variable that holds everything

--- a/src/js/routes/BridgeDetailRoute.js
+++ b/src/js/routes/BridgeDetailRoute.js
@@ -1,5 +1,5 @@
-/*global GLOBE, Ember */
-GLOBE.BridgeDetailRoute = Ember.Route.extend({
+/*global GLOBE, Em */
+GLOBE.BridgeDetailRoute = Em.Route.extend({
     model: function(params){
         return params.fingerprint;
     },

--- a/src/js/routes/RelayDetailRoute.js
+++ b/src/js/routes/RelayDetailRoute.js
@@ -1,5 +1,5 @@
-/*global GLOBE, Ember */
-GLOBE.RelayDetailRoute = Ember.Route.extend({
+/*global GLOBE, Em */
+GLOBE.RelayDetailRoute = Em.Route.extend({
     model: function(params){
         return params.fingerprint;
     },

--- a/src/js/routes/StaticRoutes.js
+++ b/src/js/routes/StaticRoutes.js
@@ -1,8 +1,8 @@
-/*global GLOBE, Ember */
+/*global GLOBE, Em */
 /**
  * Route for /index
  */
-GLOBE.IndexRoute = Ember.Route.extend({
+GLOBE.IndexRoute = Em.Route.extend({
     activate: function(){
         GLOBE.set('title', '');
     }
@@ -11,7 +11,7 @@ GLOBE.IndexRoute = Ember.Route.extend({
 /**
  * Route for /code
  */
-GLOBE.CodeRoute = Ember.Route.extend({
+GLOBE.CodeRoute = Em.Route.extend({
     activate: function(){
         GLOBE.set('title', 'Code');
     }
@@ -20,7 +20,7 @@ GLOBE.CodeRoute = Ember.Route.extend({
 /**
  * Route for /help
  */
-GLOBE.HelpRoute = Ember.Route.extend({
+GLOBE.HelpRoute = Em.Route.extend({
     activate: function(){
         GLOBE.set('title', 'Help');
     }

--- a/src/js/routes/SummarySearchRoute.js
+++ b/src/js/routes/SummarySearchRoute.js
@@ -1,5 +1,5 @@
-/*global $, GLOBE, Ember */
-GLOBE.SummarySearchRoute = Ember.Route.extend({
+/*global $, GLOBE, Em */
+GLOBE.SummarySearchRoute = Em.Route.extend({
 
     // firefox location.hash workaround
     lastPayload: null,

--- a/src/js/routes/Top10Route.js
+++ b/src/js/routes/Top10Route.js
@@ -1,5 +1,5 @@
-/*global GLOBE, Ember */
-GLOBE.Top10Route = Ember.Route.extend({
+/*global GLOBE, Em */
+GLOBE.Top10Route = Em.Route.extend({
     activate: function(){
 
         GLOBE.set('title', 'Top 10 relays');

--- a/src/js/templates/application.handlebars
+++ b/src/js/templates/application.handlebars
@@ -34,7 +34,7 @@
             <div class="pure-u-1">
                 <div class="text-content">
                     <p class="no-width-limit">
-                        Want to contribute or view the source? Check out the repository <a href="https://github.com/makepanic/globe">on <i class="fa fa-github-alt"></i> github</a>.
+                        Want to <a href="https://trac.torproject.org/projects/tor/newticket?component=Globe">report a bug</a>, contribute or view the source? Check out the repository <a href="https://github.com/makepanic/globe">on <i class="fa fa-github-alt"></i> github</a>.
                         "Tor" and the "Onion Logo" are registered trademarks of The Tor Project, Inc.
                     </p>
                 </div>

--- a/src/js/templates/toggleEnableViewLayout.handlebars
+++ b/src/js/templates/toggleEnableViewLayout.handlebars
@@ -1,7 +1,0 @@
-<label {{bindAttr title="view.title"}}">
-    {{view Ember.Checkbox checkedBinding="view.enabled"}}
-    {{view.label}}
-</label>
-<span>
-    {{yield}}
-</span>

--- a/src/js/views/HistoryGraphView.js
+++ b/src/js/views/HistoryGraphView.js
@@ -1,5 +1,5 @@
-/*global $, Dygraph, GLOBE, Ember */
-GLOBE.HistoryGraphView = Ember.View.extend({
+/*global $, Dygraph, GLOBE, Em */
+GLOBE.HistoryGraphView = Em.View.extend({
     title: 'GraphView',
     templateName: 'graphItem',
     timePeriod: '1_week',

--- a/src/js/views/SummariesView.js
+++ b/src/js/views/SummariesView.js
@@ -1,5 +1,5 @@
-/*global GLOBE, Ember */
-GLOBE.BaseSummariesView = Ember.View.extend({
+/*global GLOBE, Em */
+GLOBE.BaseSummariesView = Em.View.extend({
     tagName: 'table',
     dataTable: null,
     data: [],
@@ -186,5 +186,5 @@ GLOBE.BridgeSummariesView = GLOBE.BaseSummariesView.extend({
 });
 
 // view to hold summary view ( needed for datatables div creation outside the other summariesView )
-GLOBE.SummaryHolderView = Ember.View.extend({
+GLOBE.SummaryHolderView = Em.View.extend({
 });

--- a/test/ember-test-bootstrap.js
+++ b/test/ember-test-bootstrap.js
@@ -5,6 +5,16 @@
         document.write('<div id="ember-testing-container"><div id="ember-testing"></div></div>');
         document.write('<style>#ember-testing-container { position: absolute; top: 0; right: 0; bottom: 0; left: 0; width: 800px; height: 800px} #ember-testing { display: block }</style>');
 
+        // Test api fixtures
+        App.TESTING_FIXTURES = {
+            '/details?limit=50&search=globe integration test search expecting to find nothing&fields=fingerprint,nickname,advertised_bandwidth,last_restarted,country,flags,or_addresses,dir_address,running,hashed_fingerprint': {
+                'relays_published':'2013-12-11 20:00:00',
+                'relays': [],
+                'bridges_published':'2013-12-11 19:37:04',
+                'bridges':[]
+            }
+        };
+
         App.rootElement = '#ember-testing';
         App.setupForTesting();
         App.injectTestHelpers();

--- a/test/integration/search.test.js
+++ b/test/integration/search.test.js
@@ -5,7 +5,7 @@ module("Search tests", {
 });
 
 test('the advanced search should not be visible', function () {
-    var searchQuery = "globe integration test search expecting to find nothing " + Date.now();
+    var searchQuery = "globe integration test search expecting to find nothing";
 
     visit('/').then(function () {
         return fillIn("#main-search", searchQuery);


### PR DESCRIPTION
- added $.ajax, $.getJSON wrapper inspired by [discourse ajax](https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/mixins/ajax.js).
- added Ember shorthand `Em`
- added new Globe trac link

Using the `GLOBE.ajax` or `GLOBE.getJSON`  returns a RSVP.Promise that calls resolve or reject with `Ember.run`. This way it won't break on async operations if Ember testing is active.
